### PR TITLE
Make binaries executable in migration

### DIFF
--- a/lib/Migration/RegisterBinary.php
+++ b/lib/Migration/RegisterBinary.php
@@ -67,6 +67,9 @@ class RegisterBinary implements IRepairStep {
 			}
 		}
 
+		// Make all binaries executable
+		chmod($binaryPath, 0755);
+
 		// Write the app config
 		$this->config->setAppValue('spreed', 'matterbridge_binary', $binaryPath);
 	}


### PR DESCRIPTION
Fixes #2

While it would be possible to make just the binary being used executable, thought it would be a good idea to make them all executable in case the sysadmin moves the server from one architecture to another.